### PR TITLE
New strings from 0.9.9

### DIFF
--- a/plugin/Resources/Italian.lproj/TotalFinder.strings
+++ b/plugin/Resources/Italian.lproj/TotalFinder.strings
@@ -66,10 +66,7 @@
 "Visit Homepage" = "Visita la Homepage";
 "Please register TotalFinder" = "Per favore registra TotalFinder";
 "In the unregistered version this dialog pops up every 10 tab switches.\n\nAnnoying? This is my attempt to remind you friendly that you are
-using tabs intensively and you should buy this awesome software. It's easy. Get rid of this limitation and make my day! Thank you." = "Nella
-versione non registrata questa finestra di dialogo appare ogni 10 cambi di scheda.\n\nFastidioso? Questo è il mio tentativo di ricordarti
-amichevolmente che stai usando intensamente le schede e che dovresti comprare questo stupendo programma. È facile. Liberati di questo limite
-e migliora la mia giornata! Grazie.";
+using tabs intensively and you should buy this awesome software. It's easy. Get rid of this limitation and make my day! Thank you." = "Nella versione non registrata questa finestra di dialogo appare ogni 10 cambi di scheda.\n\nFastidioso? Questo è il mio tentativo di ricordarti amichevolmente che stai usando intensamente le schede e che dovresti comprare questo stupendo programma. È facile. Liberati di questo limite e migliora la mia giornata! Grazie.";
 "Buy TotalFinder now" = "Compra TotalFinder adesso";
 "Why should I buy?" = "Perché dovrei comprarlo?";
 "TotalFinder alpha - learn more" = "TotalFinder Alpha - più informazioni";


### PR DESCRIPTION
Hello! I updated the translation to match the last update. just a few notes:
1) thank you for your help with git! I missed some information when I learned how to use it, now it's all clear;
2) I still left in the translation two little issues (the "TF" in the asepsis page and the "tab" instead of "schede" in the experimental section) because the UI doesn't fit with long text lines; are you planning any solution for this?
3) I read on the blog that you plan to write some documentation before launching v1.0; it's no problem for me to make the translation before 1.0 version, if time doesn't conspire against us :-)
Bye!

Diego
