### PR TITLE
Added Portuguese (Portugal) translation

### DIFF
--- a/plugin/Resources/pt_PT.lproj/InfoLine.html
+++ b/plugin/Resources/pt_PT.lproj/InfoLine.html
@@ -1,0 +1,7 @@
+<style>
+    html {font-family: 'Lucida Grande', arial; font-size: 10px; cursor: default; color: #999;} 
+    html,body {overflow: hidden;}
+    a, a:visited { color: #66f; } 
+    a:hover {color: #22f}
+</style>
+<center><b>TotalFinder ##VERSION##</b> por <a href="http://binaryage.com">binaryage.com</a></center>

--- a/plugin/Resources/pt_PT.lproj/LicensingInfo.html
+++ b/plugin/Resources/pt_PT.lproj/LicensingInfo.html
@@ -1,0 +1,19 @@
+<style>
+    html{font-family:'Lucida Grande',arial;font-size:10px;cursor:default;color:#666;}
+    html,body {overflow: hidden;}
+    a,a:visited{color:#66f;}
+    a:hover{color:#22f}
+    h1{white-space:nowrap;}
+    ul{margin:0;padding:0;padding-left:16px;}
+    p{margin-bottom: 10px}
+    .choice{margin-top: 6px;}
+    .example{margin-left: 14px;margin-top: 2px; font-size: 9px;}
+    .note {font-size: 9px;}
+</style>
+
+<p>Pode utilizar a licença do TotalFinder numa de duas formas:</p>
+<div class="choice">1. <strong>Um utilizador em multiplos compradores:</strong> <span class="note">(desde que seja o unico que utiliza o TotalFinder)</span></div>
+<div class="example">Exemplo: um computador de mesa e um computador portatil, os quais sao apenas utilizados por uma pessoa;</div>
+<div class="choice">2. <strong>Multiplos utilizadores num unico computador:</strong></div>
+<div class="example">Exemplo: Um computador domestico partilhado por varios membros da mesma família.</div>
+<p class="note">Para mais informa&ccedil;&otilde;es sobre licenciamento, visite <a href="http://totalfinder.binaryage.com/licensing">http://totalfinder.binaryage.com/licensing</a></p>

--- a/plugin/Resources/pt_PT.lproj/Localizable.strings
+++ b/plugin/Resources/pt_PT.lproj/Localizable.strings
@@ -1,0 +1,71 @@
+/* navigation bar */
+"Visor" = "Visor";
+"Asepsis" = "Asepsis";
+"Tweaks" = "Modificações";
+"About" = "Sobre";
+
+/* visor page */
+"Visor Feature" = "Funcionalidade Visor";
+"a system-wide window sliding from the bottom on a hot-key" = "uma janela deslizante que é activa por um atalho";
+
+"Activation:" = "Activação:";
+
+"Control:" = "Controlo:";
+"Hide on ESC" = "Fechar com ESC";
+"Pin Visor" = "Fixar Visor";
+
+"Animation:" = "Animação:";
+"Fade Window" = "Escurecer Janela";
+"Slide Window" = "Deslizar Janela";
+
+"Screen:" = "Ecrã:";
+"Show on all Spaces" = "Mostrar em todos os Spaces";
+"Show on top of the Dock" = "Exibir em cima da Dock";
+"Free Form Window" = "Janela FreeForm";
+
+/* asepsis page */
+"Asepsis Feature" = "Funcionalidade Asepsis";
+"prevents .DS_Store files to be created in local folders" = "prevê que ficheiros .DS_Store sejam criados em pastas locais";
+".DS_Store files will be redirected into" = "ficheiros .DS_Store serão redireccionados para";
+"this folder should be set as writable for all users of TotalFinder" = "esta pasta deve poder ser escrita por todos utilizadores do TotalFinder";
+"Launch Migration Assistant" = "Abrir Assistente de Migração";
+"TotalFinder.kext status" = "Estado do TotalFinder.kext";
+"Unable to connect" = "Não foi possivel estabelecer ligação com a extensão!\nTem a certeza de que esta está instalada?";
+"Advanced:" = "Avançado:";
+"Don't write .DS_Store to Network" = "Não gravar .DS_Store em ficheiros na rede";
+
+/* tweaks page */
+"Reset TotalFinder to defaults" = "Restaurar configurações por defeito do TotalFinder";
+
+"File Browser:" = "Explorador de Ficheiros:";
+"Show System Files" = "Ficheiros de Sistema";
+"Folders on Top" = "Pastas no Topo";
+"Always Maximize" = "Maximizar Sempre";
+"Toggle Dual Mode" = "Activar Modo Duo";
+
+"Menu and Dock:" = "Menu e Dock:";
+"Hide icon in Menu Bar" = "Esconder ícone na Barra de Menus";
+"Keep original Dock icon" = "Manter ícone original na Dock";
+
+"Experimental:" = "Experimental:";
+"Freelance Windows" = "Janelas Freelance";
+"Use narrow Tabs Bar" = "Utilizar barra com abas finas";
+
+/* about page */
+"Check for updates…" = "Procurar por actualizações...";
+
+/* registration */
+"TotalFinder Registration" = "Registo do TotalFinder";
+"Registration" = "Registo";
+"Please enter your license details from the email we have sent you:" = "Por favor escreva os detalhes da licença (que estão no email que lhe enviamos):";
+"Buy TotalFinder Now" = "Comprar o TotalFinder";
+"Register" = "Registar";
+"Thanks for registering!" = "Obrigado pelo seu registo!";
+"This TotalFinder copy is licensed to:" = "Esta cópia do TotalFinder está registada para:";
+"Close" = "Fechar";
+"Change License" = "Alterar Licença";
+"Back" = "Voltar";
+"Invalid license code" = "Código de licença inválido";
+"Please go back and try again." = "Por favor tente novamente.";
+"To purchase a license for TotalFinder, please visit BinaryAge web store." = "Para comprar uma licença para o TotalFinder visite a loja virtual do BinaryAge.";
+"Thank you for using TotalFinder!" = "Obrigado por utlizar o TotalFinder!";

--- a/plugin/Resources/pt_PT.lproj/PurchaseScreen.html
+++ b/plugin/Resources/pt_PT.lproj/PurchaseScreen.html
@@ -1,0 +1,17 @@
+<style>
+    html{font-family:'Lucida Grande',arial;font-size:12px;cursor:default;color:#666;}
+    html,body {overflow: hidden;}
+    a,a:visited{color:#66f;}
+    a:hover{color:#22f}
+    h1{white-space:nowrap;}
+    ul{margin:0;padding:0;padding-left:16px;}
+    p{margin-bottom: 20px}
+</style>
+
+<p>
+Mais informa&ccedil;&otilde;es:<br/>
+P‡gina do TotalFinder: <a href="http://totalfinder.binaryage.com">http://totalfinder.binaryage.com</a><br/>
+Documenta&ccedil;&atilde;o: <a href="http://totalfinder.binaryage.com/documentation">http://.../documentation</a><br/>
+Suporte: <a href="http://support.binaryage.com">http://support.binaryage.com</a>
+</p>
+<p>O TotalFinder foi criado com o apoio de diversas ferramentas e bibliotecas de c&oacute;digo aberto. Agrade&ccedil;o muito <a href="http://totalfinder.binaryage.com/credits">aos seus autores</a>!</p>

--- a/plugin/Resources/pt_PT.lproj/ShortcutRecorder.strings
+++ b/plugin/Resources/pt_PT.lproj/ShortcutRecorder.strings
@@ -1,0 +1,13 @@
+"Space" = "Espaço";
+"Use old shortcut" = "Usar atalho antigo";
+"Type shortcut" = "Introduza o atalho";
+"Click to record shortcut" = "Clique para gravar atalho";
+"Pad %@" = "Pad %@";
+"The key combination %@ can't be used!" = "O conjunto de teclas %@ não pode ser utilizado!";
+"The key combination \"%@\" can't be used because %@." = "O conjunto de teclas \"%@\" não pode ser utilizado devido a %@.";
+"The key combination \"%@\" can't be used because it's already used by a system-wide keyboard shortcut. (If you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences.)" = "A combinação de teclas \"%@\" não pode ser usada porque já está em uso por um atalho de teclado do sistema. (Se deseja realmente utilizar esta combinação, a maioria dos atalhos podem ser modificados no painel Preferências do Sistema, em Teclado & Rato.)";
+"The key combination \"%@\" can't be used because it's already used by the menu item \"%@\"." = "A combinação de teclas \"%@\" não pode ser usada porque já está em uso por um item de menu \"%@\".";
+"Command + " = "Cmd + ";
+"Option + " = "Option + ";
+"Shift + " = "Shift + ";
+"Control + " = "Control + ";

--- a/plugin/Resources/pt_PT.lproj/TotalFinder.strings
+++ b/plugin/Resources/pt_PT.lproj/TotalFinder.strings
@@ -1,0 +1,86 @@
+/* TotalFinder Status Menu Item */
+"Check for Updates" = "Procurar Actualizações";
+"Uninstall TotalFinder" = "Desinstalar o TotalFinder";
+"Restart Finder" = "Reiniciar o Finder";
+"Show Visor" = "Mostrar Visor";
+"Hide Visor" = "Ocultar Visor";
+"Expired on %@" = "Expirado em %@";
+"This ALPHA version will expire in %@!" = "Esta versão ALPHA irá expirar em %@!";
+/* expiration date assembling for -^^ */
+"less than a minute" = "menos de um minuto";
+"1 minute" = "1 minuto";
+"less than 5 seconds" = "menos de 5 segundos";
+"less than 10 seconds" = "menos de 10 segundos";
+"less than 20 seconds" = "menos de 20 segundos";
+"half a minute" = "meio minuto";
+"%.0f minutes" = "%.0f minutos";
+"about 1 hour" = "aprox. uma hora";
+"about %.0f hours" = "aprox. %.0f horas";
+"1 day" = "um dia";
+"%.0f days" = "%.0f dias";
+"about 1 month" = "aprox. um mês";
+"%.0f months" = "%.0f meses";
+"about 1 year" = "aprox. um ano";
+"over %.0f years" = "mais de %.0f anos";
+
+/* Asepsis preferences pane */
+"Disconnect" = "Desligar";
+"Connect" = "Ligar";
+"Unable to connect with kernel extension! Do you have TotalFinder.kext properly installed?" = "Não foi possível ligar à extensão do kernel!\nDe certeza que esta foi instalada?";
+
+/* About preferences pane */
+"from Beta Channel" = "do Canal Beta";
+"from Dev Channel" = "do Canal Dev";
+"from Stable Channel" = "do Canal Stable";
+
+/* Reset to Defaults Alert Box */
+"Reset" = "Restaurar";
+"Cancel" = "Cancelar";
+"Do you really want reset to defaults?" = "Tem a certeza que deseja restaurar as definições padrão?";
+"This will restore initial TotalFinder settings." = "Isto irá restaurar a configuração do TotalFinder para os valores padrão..";
+
+/* Unistall Alert Box */
+"Uninstall" = "Desinstalar";
+"Really want to uninstall TotalFinder?" = "Deseja mesmo desinstalar o TotalFinder?";
+"This will launch an uninstall script which will remove TotalFinder from this computer and restore your original Finder behavior." = "Isto irá iniciar um script que irá remover o TotalFinder deste computador e restaurar o comportamento original do Finder.";
+
+/* MainMenu items */
+"New Finder Tab" = "Nova aba do Finder";
+"Close Tab" = "Fechar aba";
+"Close Window" = "Fechar janela";
+"Show System Files" = "Mostrar Arquivos de Sistema";
+"Folders On Top" = "Pastas em Cima";
+"Toggle Dual Mode" = "Activar/Desactivar Modo Dual";
+"Narrow Tabs Bar" = "Barra de Abas Fina";
+"Pin Visor" = "Fixar Visor";
+"TotalFinder Preferences…" = "Preferências do TotalFinder…";
+"Visit Homepage…" = "Visitar Homepage…";
+
+/* misc. */
+"Screen %d" = "Ecrã %d";
+
+/* Dialogs related to optional notice dialogs in the top-right corner of the main frame window with tabs */
+"TotalFinder ALPHA has expired" = "TotalFinder ALFA expirou";
+"In the expired version this dialog pops up every 10 tab switches.\n\nI just want you to upgrade to the latest TotalFinder version. It should take just a few minutes. Please check for updates." = "Na versão expirada este diálogo aparece a cada 10 trocas de aba.\n\nGostaria que actualizasse para a última versão do TotalFinder. Isto deve apenas demorar alguns minutos. Por favor, procure por actualizações..";
+"Check for updates" = "Verificar actualizações";
+"Visit Homepage" = "Visitar Homepage";
+"Please register TotalFinder" = "Por favor, registe o TotalFinder";
+"In the unregistered version this dialog pops up every 10 tab switches.\n\nAnnoying? This is a reminder that you are using tabs intensively and you should buy this awesome software. It's easy. Get rid of this limitation and make my day. Thanks!" = "Na versão não registada este diálogo aparece a cada 10 trocas de aba.\n\nIrritante? Isto é um aviso que está a usar muito as funcionalidade de abas e portanto deveria comprar esta peça de software fascinante. É fácil. Faça-o e eu ganharei o dia! Obrigado!";
+"Buy TotalFinder now" = "Comprar o TotalFinder agora";
+"Why should I buy?" = "Porque devo comprar o TotalFinder?";
+"TotalFinder alpha - learn more" = "TotalFinder alpha - saiba mais";
+"TotalFinder expired - please upgrade" = "O TotalFinder expirou - por favor actualize";
+"TotalFinder - unregistered version" = "TotalFinder - versão não registada";
+"TotalFinder will be a paid software soon" = "O TotalFinder será um software pago em breve";
+"I just want to remind you that this is a free alpha version, but TotalFinder will become a paid software when it hits 1.0 version. You cannot stick with an alpha version, because it is going to expire at some point.\n\nThank you for helping me test this Finder plugin.\nI hope you find it useful and consider to support its further development by buying it." = "Eu apenas gostaria de lhe lembrar que esta é uma versão livre (alpha), mas o TotalFinder passará a ser pago quando atingir a versão 1.0. Você não pode ficar com uma versão alpha, pois ela expirará.\n\nObrigado por me ajudar a testar este plugin para o Finder.\nEu espero que o ache útil e que o compre de modo a ajudar o seu desenvolvimento!";
+"Sure, I understand" = "Eu percebi";
+
+/* registration */
+"You may buy TotalFinder soon." = "Em breve poderá comprar o TotalFinder.";
+"TotalFinder will become a commercial app on Sep 27, 2010. The registration dialog is disabled until that day.\n\nPlease wait for the 1.0 release. And by the way, thanks for clicking this button :-)" = "O TotalFinder passará a pago no dia 27 de Setembro de 2010. O diálogo de registo está desactivo até esse dia.\n\nPor favor espere pela versão 1.0. E já agora, obrigado por clicar neste botão :-)";
+"OK" = "OK";
+"Read Article" = "Ler Artigo";
+"Licensed to %@" = "Registado para %@";
+"Change License" = "Mudar Licença";
+"Unregistered version in trial mode" = "Versão não registrada em modo de teste";
+"Register" = "Registar";


### PR DESCRIPTION
TotalFinder only had a Brazilian Portuguese translation, which 1. doesn't work on Portuguese (Portugal) computers and 2. I felt Portuguese (Portugal) was needed. :)
