### PR TITLE
Fixed typo for German "Cut “%@”" string in context menu.

### DIFF
--- a/plugin/Resources/German.lproj/CutAndPaste.strings
+++ b/plugin/Resources/German.lproj/CutAndPaste.strings
@@ -4,7 +4,7 @@
 /* sample screenshot of English version: http://dl.dropbox.com/u/559047/Screenshots/qigu.png */
 "Edit" = "Bearbeiten";
 "Cut" = "Ausschneiden";
-"Cut “%@”" = "Ausschneiden “%@”";
+"Cut “%@”" = "“%@” Ausschneiden";
 "Cut %u Items" = "%u Elemente ausschneiden";
 "Paste" = "Einfügen";
 "Paste %u Items" = "%u Elemente einfügen";


### PR DESCRIPTION
Hope this helps :)
