### PR TITLE
There. I fixed it. :D

### DIFF
--- a/installer/Spanish.lproj/welcome.rtf
+++ b/installer/Spanish.lproj/welcome.rtf
@@ -4,22 +4,22 @@
 {\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid1\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid1}
 {\list\listtemplateid2\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid101\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid2}}
 {\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}}
-\paperw11900\paperh16840\margl1440\margr1440\vieww16580\viewh17820\viewkind0
+\paperw11904\paperh16836\margl1440\margr1440\vieww16580\viewh14180\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\ql\qnatural\pardirnatural
 
-\f0\fs28 \cf0 Este instalador configurar\'e1 {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com"}}{\fldrslt 
+\f0\fs28 \cf0 Este instalador instalar\'e1 {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com"}}{\fldrslt 
 \b TotalFinder}} en su ordenador.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\ql\qnatural\pardirnatural
-\cf2 Finaliza todos los trabajos en segundo llano, como copiar o mover archivos.\cf3 \
+\cf2 Por favor termine todos los procesos en segundo plano como copiar o mover archivos.\cf3 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\ql\qnatural\pardirnatural
 \cf0 El Finder se reiniciar\'e1 durante la instalaci\'f3n.\
 \
-TotalFinder es un complement para el Finder que a\'f1ade pesta\'f1as, modo doble y m\'e1s. Para leer m\'e1s sobre TotalFinder, visite {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/about"}}{\fldrslt http://totalfinder.binaryage.com/about}}\
+TotalFinder es un complement para el Finder que a\'f1ade pesta\'f1as, p\'e1neles dobles y m\'e1s funcionalidad. Para leer m\'e1s sobre TotalFinder, visite {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/about"}}{\fldrslt http://totalfinder.binaryage.com/about}}\
 \
-Tienes 14 d\'edas para probar el producto. Para m\'e1s informaci\'f3n sobre las licencias, visite {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/licensing"}}{\fldrslt http://totalfinder.binaryage.com/licensing}}\
+Tiene 14 d\'edas para probar el producto. Para m\'e1s informaci\'f3n sobre las licencias, visite {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/licensing"}}{\fldrslt http://totalfinder.binaryage.com/licensing}}\
 \
-TotalFinder se compone de tres partes:\
+TotalFinder consiste de tres partes:\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\ql\qnatural\pardirnatural
 \ls1\ilvl0\cf0 {\listtext	\'95	}TotalFinder.app - complemento del Finder y lanzador\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\ql\qnatural\pardirnatural

--- a/plugin/Resources/Spanish.lproj/InfoLine.html
+++ b/plugin/Resources/Spanish.lproj/InfoLine.html
@@ -4,4 +4,4 @@
     a, a:visited { color: #66f; } 
     a:hover {color: #22f}
 </style>
-<center><b>TotalFinder ##VERSION##</b> de <a href="http://binaryage.com">binaryage.com</a></center>
+<center><b>TotalFinder ##VERSION##</b> por <a href="http://binaryage.com">binaryage.com</a></center>

--- a/plugin/Resources/Spanish.lproj/LicensingInfo.html
+++ b/plugin/Resources/Spanish.lproj/LicensingInfo.html
@@ -12,8 +12,8 @@
 </style>
 
 <p>Puede usar su licencia de dos formas distintas:</p>
-<div class="choice">1. <strong>un usuario en multiples ordenadores</strong> <span class="note">(siempre y cuando sea el único usuario que utiliza TotalFinder)</span></div>
-<div class="example">Ejemplo: un ordenador de escritorio y un portátil que son exclusivamente utilizados por usted</div>
-<div class="choice">2. <strong>multiples usuarios en un solo ordenador</strong></div>
-<div class="example">Ejemplo: un ordenador del hogar compartido por todos los miembros de la familia</div>
-<p class="note">Para más información sobre las licencias visite <a href="http://totalfinder.binaryage.com/licensing">http://totalfinder.binaryage.com/licensing</a></p>
+<div class="choice">1. <strong>un usuario en múltiples ordenadores</strong> <span class="note">(siempre y cuando usted sea el único usuario que utiliza TotalFinder)</span></div>
+<div class="example">Ejemplo: un ordenador de escritorio y un portátil utilizados exclusivamente por usted</div>
+<div class="choice">2. <strong>múltiples usuarios en un solo ordenador</strong></div>
+<div class="example">Ejemplo: un ordenador de hogar compartido por todos los miembros de la familia</div>
+<p class="note">Para más información sobre las licencias, visite <a href="http://totalfinder.binaryage.com/licensing">http://totalfinder.binaryage.com/licensing</a></p>

--- a/plugin/Resources/Spanish.lproj/PurchaseScreen.html
+++ b/plugin/Resources/Spanish.lproj/PurchaseScreen.html
@@ -10,7 +10,7 @@
 
 <p>
 Más información:<br/>
-Pagina web: <a href="http://totalfinder.binaryage.com">http://totalfinder.binaryage.com</a><br/>
+Página web: <a href="http://totalfinder.binaryage.com">http://totalfinder.binaryage.com</a><br/>
 Documentación: <a href="http://totalfinder.binaryage.com/documentation">http://.../documentation</a><br/>
 Soporte: <a href="http://support.binaryage.com">http://support.binaryage.com</a>
 </p>

--- a/plugin/Resources/Spanish.lproj/ShortcutRecorder.strings
+++ b/plugin/Resources/Spanish.lproj/ShortcutRecorder.strings
@@ -1,12 +1,12 @@
 "Space" = "Espacio";
 "Use old shortcut" = "Usar anterior";
 "Type shortcut" = "Pulsar teclas";
-"Click to record shortcut" = "Clic para crear";
+"Click to record shortcut" = "Clic para definir atajo";
 "Pad %@" = "Rellenar %@";
-"The key combination %@ can't be used!" = "La combinación de teclas %@ no puede ser utilizada";
+"The key combination %@ can't be used!" = "¡La combinación de teclas %@ no puede ser utilizada!";
 "The key combination \"%@\" can't be used because %@." = "La combinación de teclas \"%@\" no puede ser utilizada porque %@.";
-"The key combination \"%@\" can't be used because it's already used by a system-wide keyboard shortcut. (If you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences.)" = "La combinación de teclas \"%@\" no puede ser utilizada porque está en uso como una función rápida de teclado del sistema. (Si realmente desea usar esta combinación de teclas, la mayoría de las funciones rápidas se pueden cambiar en el panel Teclado de las Preferencias del Sistema.)";
-"The key combination \"%@\" can't be used because it's already used by the menu item \"%@\"." = "La combinación de teclas \"%@\" no puede ser usada porque está en uso para el elemento de menú \"%@\".";
+"The key combination \"%@\" can't be used because it's already used by a system-wide keyboard shortcut. (If you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences.)" = "La combinación de teclas \"%@\" no puede ser utilizada porque está en uso como una atajo de teclado del sistema. (Si desea usar esta combinación de teclas, la mayoría de las funciones rápidas se pueden cambiar en el panel de Teclado en las Preferencias del Sistema.)";
+"The key combination \"%@\" can't be used because it's already used by the menu item \"%@\"." = "La combinación de teclas \"%@\" no puede ser usada porque está en uso por el elemento de menú \"%@\".";
 "Command + " = "Comando + ";
 "Option + " = "Opción + ";
 "Shift + " = "Mayúsculas + ";

--- a/plugin/Resources/Spanish.lproj/TotalFinder.strings
+++ b/plugin/Resources/Spanish.lproj/TotalFinder.strings
@@ -12,19 +12,19 @@
 
 /* About preferences pane */
 "from Beta Channel" = "del Canal Beta";
-"from Dev Channel" = "del Canal Dev";
-"from Stable Channel" = "del Canal Stable";
+"from Dev Channel" = "del Canal de Desarrollo";
+"from Stable Channel" = "del Canal Estable";
 
 /* Reset to Defaults Alert Box */
 "Reset" = "Restaurar";
 "Cancel" = "Cancelar";
-"Do you really want reset to defaults?" = "¿Desea restaurar a los valores por omisión?";
+"Do you really want reset to defaults?" = "¿Desea restaurar a los valores de fábrica?";
 "This will restore initial TotalFinder settings." = "Esta operación restaurará la configuración original de TotalFinder.";
 
 /* Unistall Alert Box */
 "Uninstall" = "Desinstalar";
-"Really want to uninstall TotalFinder?" = "¿Desea desinstalar TotalFinder?";
-"This will launch an uninstall script which will remove TotalFinder from this computer and restore your original Finder behavior." = "Esta operación va a iniciar un script que desinstalará TotalFinder de este ordenador y restaurará el comportamiento original de Finder.";
+"Really want to uninstall TotalFinder?" = "¿Está seguro que desea desinstalar TotalFinder?";
+"This will launch an uninstall script which will remove TotalFinder from this computer and restore your original Finder behavior." = "Esta operación va a iniciar una rutina que desinstalará TotalFinder de este ordenador y restaurará el comportamiento original del Finder.";
 
 /* MainMenu items */
 "New Finder Tab" = "Nueva pestaña del Finder";
@@ -50,10 +50,10 @@
 "TotalFinder - 3 days left - buy now!" = "TotalFinder - 3 días restantes - ¡cómpralo ya!";
 "TotalFinder - 4 days left - buy now!" = "TotalFinder - 4 días restantes - ¡cómpralo ya!";
 "TotalFinder - 5 days left - buy now!" = "TotalFinder - 5 días restantes - ¡cómpralo ya!";
-"TotalFinder - %d days left - buy now!" = "TotalFinder - %d  días restantes - ¡cómpralo ya!";
+"TotalFinder - %d days left - buy now!" = "TotalFinder - %d días restantes - ¡cómpralo ya!";
 
 /* registration */
 "Licensed to %@" = "Licenciado a %@";
 "Change License" = "Cambiar Licencia";
-"Unregistered version in trial mode" = "Versión no registrada (modo de prueba)";
+"Unregistered version in trial mode" = "Versión no registrada en modo de prueba";
 "Register" = "Registrar";

--- a/plugin/Resources/Spanish.lproj/TotalFinderUI.strings
+++ b/plugin/Resources/Spanish.lproj/TotalFinderUI.strings
@@ -6,7 +6,7 @@
 
 /* visor page */
 "Visor Feature" = "Activar Visor";
-"a system-wide window sliding from the bottom on a hot-key" = "ventana global invocada con una función rápida de teclado";
+"a system-wide window sliding from the bottom on a hot-key" = "una ventana global invocada con un atajo de teclado";
 
 "Activation:" = "Activación:";
 
@@ -19,15 +19,15 @@
 "Slide Window" = "Deslizar Ventana";
 
 "Screen:" = "Pantalla:";
-"Show on all Spaces" = "Mostrar en todos los Spaces";
+"Show on all Spaces" = "Mostrar en todos los Espacios";
 "Show on top of the Dock" = "Mostrar sobre el Dock";
-"Free Form Window" = "Ventana redimensionable";
+"Free Form Window" = "Ventana Redimensionable";
 
 /* asepsis page */
 "Asepsis Feature" = "Activar Asepsia";
 "prevents .DS_Store files to be created in local folders" = "evita que se creen archivos .DS_Store en las carpetas locales";
 ".DS_Store files will be redirected into" = "Los archivos .DS_Store serán redirigidos a";
-"this folder should be set as writable for all users of TotalFinder" = "(necesita permisos de escritura para todos los usarios de TotalFinder)";
+"this folder should be set as writable for all users of TotalFinder" = "necesita permisos de escritura en esta carpeta para todos los usarios de TotalFinder";
 "Launch Migration Assistant" = "Lanzar Asistente de Migración";
 "TotalFinder.kext status" = "Estado de TotalFinder.kext";
 "Unable to connect" = "No es posible conectar con la extensión del kernel.\n¿Tiene la extensión del kernel correctamente instalada?";
@@ -35,21 +35,21 @@
 "Don't write .DS_Store to Network" = "No escribir .DS_Store en unidades de Red"; /* 'unidades de Red' deducido de aquí: http://www.apple.com/es/macosx/what-is-macosx/dock-and-finder.html */
 
 /* tweaks page */
-"Reset TotalFinder to defaults" = "Restaurar valores por omisión";
+"Reset TotalFinder to defaults" = "Restaurar valores predeterminados";
 
 "File Browser:" = "Navegador de Archivos:";
-"Show System Files" = "Ver Archiv. del Sistema";
+"Show System Files" = "Ver Archivos del Sistema";
 "Folders on Top" = "Carpetas primero";
-"Always Maximize" = "Maximizar completamente";
+"Always Maximize" = "Maximizar siempre";
 "Toggle Dual Mode" = "Cambiar a Modo Dual";
 
 "Menu and Dock:" = "Menú y Dock:";
-"Hide icon in Menu Bar" = "Ocultar icono de la Barra de Menú";
-"Keep original Dock icon" = "Usar icono original de Finder en el Dock";
+"Hide icon in Menu Bar" = "Ocultar ícono de la Barra de Menú";
+"Keep original Dock icon" = "Usar ícono original del Finder en el Dock";
 
 "Experimental:" = "Experimental:";
 "Freelance Windows" = "No agrupar ventanas";
-"Use narrow Tabs Bar" = "Barra Pestañas estrecha";
+"Use narrow Tabs Bar" = "Usar Barra de Pestañas estrecha";
 "Show CutPaste buttons in Context Menus" = "Mostrar Cortar y Pegar en el menú contextual";
 
 /* about page */
@@ -58,7 +58,7 @@
 /* registration */
 "TotalFinder Registration" = "Registro de TotalFinder";
 "Registration" = "Registro";
-"Please enter your license details from the email we have sent you:" = "Introduzca sus datos de licencia, del correo electrónico que le hemos enviado:";
+"Please enter your license details from the email we have sent you:" = "Introduzca los datos de licencia del correo electrónico que le hemos enviado:";
 "Buy TotalFinder Now" = "Comprar TotalFinder";
 "Register" = "Registrar";
 "Thanks for registering!" = "¡Gracias por registrarse!";
@@ -68,5 +68,5 @@
 "Back" = "Volver";
 "Invalid license code" = "Código de lincencia inválido";
 "Please go back and try again." = "Vuelva atrás e inténtelo de nuevo.";
-"To purchase a license for TotalFinder, please visit BinaryAge web store." = "Para comprar una licencia de TotalFinder puede visitar la página web de BinaryAge.";
+"To purchase a license for TotalFinder, please visit BinaryAge web store." = "Para comprar una licencia de TotalFinder, visite la página web de BinaryAge.";
 "Thank you for using TotalFinder!" = "¡Gracias por utilizar TotalFinder!";


### PR DESCRIPTION
I updated the Spanish localization. There were some missing punctuation marks and one or two grammatical/spelling mistakes. Some of the strings were also ambiguous, so I corrected their wording.

Also, I couldn't run a "rake validate" command. It returned: 

no such file to load -- cmess/guess_encoding
~/Code/totalfinder-i18n/rakefile:344:in `validate_strings_files'
(See full trace by running task with --trace)

So apparently your rakefile is corrupt. 

I tested the changes and it all renders correctly.
