### PR TITLE
Little portuguese's correction

### DIFF
--- a/plugin/Resources/pt_BR.lproj/TotalFinderUI.strings
+++ b/plugin/Resources/pt_BR.lproj/TotalFinderUI.strings
@@ -10,7 +10,7 @@
 
 "Activation:" = "Activação:";
 
-"Control:" = "Controlo:";
+"Control:" = "Controle:";
 "Hide on ESC" = "Fechar com ESC";
 "Pin Visor" = "Fixar Visor";
 


### PR DESCRIPTION
Hello 

I changed Controlo to Controle (that is the correct word in portuguese)

Best,
Pablo Cantero
