### PR TITLE
Improved Dutch language files

### DIFF
--- a/crashwatcher/Dutch.lproj/Localizable.strings
+++ b/crashwatcher/Dutch.lproj/Localizable.strings
@@ -1,14 +1,14 @@
 "crashDialogHeader" = "TotalFinder is onverwacht gestopt";
 "crashDialogMsg" = "Het spijt ons, in TotalFinder is een probleem opgetreden waardoor Finder is gecrasht.";
-"crashDialogNote" = "NB: Finder is automatisch opnieuw opgestart maar u dient TotalFinder.app nog handmatig te starten.";
-"crashDialogExplanation" = "Door op Stuur Email te klikken wordt het rapport naar gist.github.com geüpload en zal Mail.app worden geopend met een mailconcept.";
+"crashDialogNote" = "NB: Finder is automatisch opnieuw opgestart, maar u dient TotalFinder.app nog handmatig te starten.";
+"crashDialogExplanation" = "Door op 'Stuur e-mail' te klikken wordt het rapport naar gist.github.com geüpload en zal Mail.app worden geopend met een mailconcept.";
 
 "failDialogHeader" = "Het rapport kon niet worden geüpload naar gist.github.com";
 "failDialogMsg1" = "Het rapport is niet gevonden in ~/Logs/CrashReporter.";
-"failDialogMsg2" = "Het rapport is gevonden, maar uploaden naar gist.github.com is mislukt.\n\nDringend? Stuur alstublieft een email naar:\n%@";
+"failDialogMsg2" = "Het rapport is gevonden, maar uploaden naar gist.github.com is mislukt.\n\nDringend? Stuur alstublieft een e-mail naar:\n%@";
 "failDialogOK" = "OK";
 
-"sendReportButton" = "Stuur Email";
+"sendReportButton" = "Stuur e-mail";
 "cancelButton" = "Annuleer";
 
 "emailTemplate" = "Hi Antonin,\n\nMy %@ just crashed!\n\nThe crash report is available here:\n%@\n\n>\n> U kunt me helpen het probleem op te lossen door te beschrijven wat u deed vóór de crash.\n> Ik waardeer uw hulp en lees de rapporten, verwacht echter geen direct antwoord.\n> Voor verdere opmerkingen meldt u het probleem op\n> http://getsatisfaction.com/binaryage.\n>\n> Hartelijk dank, Antonin";

--- a/installer/Dutch.lproj/welcome.rtf
+++ b/installer/Dutch.lproj/welcome.rtf
@@ -15,13 +15,13 @@
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural
 \cf0 Finder zal opnieuw worden opgestart tijdens de installatie.\
 \
-TotalFinder is een Finder plugin welke tabbladen, dubbele panelen en andere functionaliteit toevoegt. Om meer over TotalFinder te weten te komen, bezoek {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/about"}}{\fldrslt http://totalfinder.binaryage.com/about}}\
+TotalFinder is een Finder-plugin die tabbladen, dubbele panelen en andere functionaliteiten toevoegt. Om meer over TotalFinder te weten te komen, bezoekt u {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/about"}}{\fldrslt http://totalfinder.binaryage.com/about}}\
 \
-U heeft 14 dagen om het product te proberen. Voor meer informatie omtrent licenties bezoekt u {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/licensing"}}{\fldrslt http://totalfinder.binaryage.com/licensing}}\
+U heeft 14 dagen de tijd om het product te proberen. Voor meer informatie omtrent licenties, bezoekt u {\field{\*\fldinst{HYPERLINK "http://totalfinder.binaryage.com/licensing"}}{\fldrslt http://totalfinder.binaryage.com/licensing}}\
 \
-TotalFinder bestaat uit drie bestanden:\
+TotalFinder bestaat uit drie onderdelen:\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural
-\ls1\ilvl0\cf0 {\listtext	\'95	}TotalFinder.app - Finder plugin en opstartprogramma\
+\ls1\ilvl0\cf0 {\listtext	\'95	}TotalFinder.app - Finder-plugin en opstartprogramma\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural
-\ls2\ilvl0\cf0 {\listtext	\'95	}TotalFinder.osax - script toevoegingen voor Finder\
+\ls2\ilvl0\cf0 {\listtext	\'95	}TotalFinder.osax - scripting-toevoegingen voor Finder\
 {\listtext	\'95	}TotalFinder.kext - systeemextensie (optioneel)}

--- a/plugin/Dutch.lproj/CopyPathMenuUI.strings
+++ b/plugin/Dutch.lproj/CopyPathMenuUI.strings
@@ -1,6 +1,6 @@
-"Copy Path" = "Kopieer pad";
-"POSIX Path" = "POSIX pad";
+"Copy Path" = "Kopieerpad";
+"POSIX Path" = "POSIX-pad";
 "URL" = "URL";
-"Windows Path" = "Windows pad";
-"HFS Path" = "HFS pad";
-"Terminal Path" = "Terminal pad";
+"Windows Path" = "Windows-pad";
+"HFS Path" = "HFS-pad";
+"Terminal Path" = "Terminal-pad";

--- a/plugin/Dutch.lproj/CutAndPaste.strings
+++ b/plugin/Dutch.lproj/CutAndPaste.strings
@@ -3,8 +3,8 @@
 /* do not translate it directly from English but look how your menu looks in your language */
 /* sample screenshot of English version: http://dl.dropbox.com/u/559047/Screenshots/qigu.png */
 "Edit" = "Wijzig";
-"Cut" = "Knip";
+"Cut" = "Knippen";
 "Cut “%@”" = "Knip “%@”";
 "Cut %u Items" = "Knip %u onderdelen";
-"Paste" = "Plak";
+"Paste" = "Plakken";
 "Paste %u Items" = "Plak %u onderdelen";

--- a/plugin/Dutch.lproj/CutAndPasteUI.strings
+++ b/plugin/Dutch.lproj/CutAndPasteUI.strings
@@ -1,3 +1,3 @@
-"Paste" = "Plak";
-"Copy" = "Kopieer";
-"Cut" = "Knip";
+"Paste" = "Plakken";
+"Copy" = "Kopiëren";
+"Cut" = "Knippen";

--- a/plugin/Dutch.lproj/LicensingInfo.html
+++ b/plugin/Dutch.lproj/LicensingInfo.html
@@ -13,8 +13,8 @@
 
 <p>U mag uw licentie gebruiken op één van deze twee manieren:</p>
 
-<div class="choice">1. <strong>één gebruiker op meerdere computers</strong> <span class="note">(zo lang u de enige gebruiker bent die TotalFinder gebruikt)</span></div>
-<div class="example">Voorbeeld: een desktop computer en een persoonlijke laptop die beiden enkel door u worden gebruikt</div>
+<div class="choice">1. <strong>één gebruiker op meerdere computers</strong> <span class="note">(zolang u de enige gebruiker bent die TotalFinder gebruikt)</span></div>
+<div class="example">Voorbeeld: een desktopcomputer en een persoonlijke laptop die beiden enkel door u worden gebruikt</div>
 <div class="choice">2. <strong>meerdere gebruikers op één computer</strong></div>
 <div class="example">Voorbeeld: een thuiscomputer die gedeeld wordt met alle familieleden</div>
-<p class="note">Voor meer informatie over licenties kan u <a href="http://totalfinder.binaryage.com/licensing">http://totalfinder.binaryage.com/licensing</a> bezoeken</p>
+<p class="note">Voor meer informatie over licenties kunt u kijken op <a href="http://totalfinder.binaryage.com/licensing">http://totalfinder.binaryage.com/licensing</a>.</p>

--- a/plugin/Dutch.lproj/PurchaseScreen.html
+++ b/plugin/Dutch.lproj/PurchaseScreen.html
@@ -8,5 +8,10 @@
     p{margin-bottom: 20px}
 </style>
 
-<p>Tijdens de ontwikkeling van TotalFinder heb ik verschillende <a href="http://totalfinder.binaryage.com/credits">tools en open-source libraries</a> gebruikt. Veel dank aan de auteurs!</p>
-<p>Voor het laatste nieuws, ga naar <a href="http://totalfinder.binaryage.com">http://totalfinder.binaryage.com</a></p>
+<p>
+Meer informatie:<br/>
+Homepage: <a href="http://totalfinder.binaryage.com">http://totalfinder.binaryage.com</a><br/>
+Documentatie: <a href="http://totalfinder.binaryage.com/doc">http://totalfinder.binaryage.com/doc</a><br/>
+Ondersteuning: <a href="http://support.binaryage.com">http://support.binaryage.com</a><br/>
+Credits: <a href="http://totalfinder.binaryage.com/credits">http://totalfinder.binaryage.com/credits</a><br/>
+</p>

--- a/plugin/Dutch.lproj/ShortcutRecorder.strings
+++ b/plugin/Dutch.lproj/ShortcutRecorder.strings
@@ -1,7 +1,7 @@
-"Space" = "Spatiebalk";
+"Space" = "Spatie";
 "Use old shortcut" = "Gebruik vorige toetscombinatie";
 "Type shortcut" = "Druk toetscombinatie in";
-"Click to record shortcut" = "Toetscombinatie opnemen";
+"Click to record shortcut" = "Toetscombinatie kiezen";
 "Pad %@" = "Nummertoets %@";
 "The key combination %@ can't be used!" = "De toetscombinatie %@ kan niet gebruikt worden!";
 "The key combination \"%@\" can't be used because %@." = "De toetscombinatie \"%@\" kan niet gebruikt worden, omdat %@.";

--- a/plugin/Dutch.lproj/TotalFinder.strings
+++ b/plugin/Dutch.lproj/TotalFinder.strings
@@ -1,5 +1,5 @@
 /* TotalFinder Status Menu Item */
-"Check for Updates" = "Check voor updates";
+"Check for Updates" = "Controleren op updates";
 "Uninstall TotalFinder" = "Verwijder TotalFinder";
 "Restart Finder" = "Herstart Finder";
 "Show Visor" = "Activeer Visor";
@@ -8,32 +8,32 @@
 /* Asepsis preferences pane */
 "Disconnect" = "Verbinding verbreken";
 "Connect" = "Verbinden";
-"Unable to connect with kernel extension! Do you have TotalFinder.kext properly installed?" = "Kan niet verbinden met de kernel extensie! Is de TotalFinder.kext goed geïnstalleerd?";
+"Unable to connect with kernel extension! Do you have TotalFinder.kext properly installed?" = "Kan niet verbinden met de kernelextensie! Is de TotalFinder.kext goed geïnstalleerd?";
 
 /* About preferences pane */
-"from Beta Channel" = "in het Beta kanaal";
-"from Dev Channel" = "in het Dev kanaal";
-"from Stable Channel" = "in het Stable kanaal";
+"from Beta Channel" = "in het Beta-kanaal";
+"from Dev Channel" = "in het Dev-kanaal";
+"from Stable Channel" = "in het Stable-kanaal";
 
 /* Reset to Defaults Alert Box */
 "Reset" = "Herstel";
 "Cancel" = "Annuleren";
-"Do you really want reset to defaults?" = "Wilt u echt terug naar de standaard instellingen?";
-"This will restore initial TotalFinder settings." = "Dit zal de standaard instellingen van TotalFinder herstellen.";
+"Do you really want reset to defaults?" = "Wilt u echt terug naar de standaardinstellingen?";
+"This will restore initial TotalFinder settings." = "Dit zal de standaardinstellingen van TotalFinder herstellen.";
 
 /* Unistall Alert Box */
 "Uninstall" = "Verwijderen";
 "Really want to uninstall TotalFinder?" = "Wilt u echt TotalFinder verwijderen?";
-"This will launch an uninstall script which will remove TotalFinder from this computer and restore your original Finder behavior." = "Dit start een script dat TotalFinder van de computer zal verwijderen en het originele Finder gedrag zal herstellen.";
+"This will launch an uninstall script which will remove TotalFinder from this computer and restore your original Finder behavior." = "Dit start een script dat TotalFinder van de computer zal verwijderen en het originele Finder-gedrag zal herstellen.";
 
 /* MainMenu items */
-"New Finder Tab" = "Nieuw Finder tabblad";
+"New Finder Tab" = "Nieuw Finder-tabblad";
 "Close Tab" = "Sluit tabblad";
 "Close Window" = "Sluit venster";
 "Show System Files" = "Toon systeembestanden";
-"Folders On Top" = "Mappen eerst";
+"Folders On Top" = "Mappen bovenaan";
 "Toggle Dual Mode" = "Dubbele/enkele kolom";
-"Narrow Tabs Bar" = "Smalle tabbladen balk";
+"Narrow Tabs Bar" = "Smalle tabbalk";
 "Pin Visor" = "Zet Visor vast";
 "TotalFinder Preferences…" = "TotalFinder voorkeuren…";
 "Visit Homepage…" = "Ga naar de homepage…";
@@ -45,15 +45,15 @@
 
 /* status badge */
 "TotalFinder - unregistered version" = "TotalFinder - ongelicenseerde versie";
-"TotalFinder - 1 day left - buy now!" = "TotalFinder - 1 dag over - koop nu!";
-"TotalFinder - 2 days left - buy now!" = "TotalFinder - 2 dagen over - koop nu!";
-"TotalFinder - 3 days left - buy now!" = "TotalFinder - 3 dagen over - koop nu!";
-"TotalFinder - 4 days left - buy now!" = "TotalFinder - 4 dagen over - koop nu!";
-"TotalFinder - 5 days left - buy now!" = "TotalFinder - 5 dagen over - koop nu!";
-"TotalFinder - %d days left - buy now!" = "TotalFinder - %d dagen over - koop nu!";
+"TotalFinder - 1 day left - buy now!" = "TotalFinder - nog 1 dag - koop nu!";
+"TotalFinder - 2 days left - buy now!" = "TotalFinder - nog 2 dagen - koop nu!";
+"TotalFinder - 3 days left - buy now!" = "TotalFinder - nog 3 dagen - koop nu!";
+"TotalFinder - 4 days left - buy now!" = "TotalFinder - nog 4 dagen - koop nu!";
+"TotalFinder - 5 days left - buy now!" = "TotalFinder - nog 5 dagen - koop nu!";
+"TotalFinder - %d days left - buy now!" = "TotalFinder - nog %d dagen - koop nu!";
 
 /* registration */
 "Licensed to %@" = "Gelicenseerd aan %@";
 "Change License" = "Wijzig licentie";
-"Unregistered version in trial mode" = "Ongeregistreerde verse in demo mode";
+"Unregistered version in trial mode" = "Ongeregistreerde versie in probeermodus";
 "Register" = "Registreer";

--- a/plugin/Dutch.lproj/TotalFinderUI.strings
+++ b/plugin/Dutch.lproj/TotalFinderUI.strings
@@ -5,8 +5,8 @@
 "About" = "Over";
 
 /* visor page */
-"Visor Feature" = "De Visor Optie";
-"a system-wide window sliding from the bottom on a hot-key" = "een venster even breed als uw monitor dat binnenschuift van beneden bij een toetscombinatie";
+"Visor Feature" = "De Visor-functie";
+"a system-wide window sliding from the bottom on a hot-key" = "een schermbreed venster dat van beneden binnenschuift met één toetscombinatie";
 
 "Activation:" = "Activatie:";
 
@@ -15,60 +15,60 @@
 "Pin Visor" = "Zet Visor vast";
 
 "Animation:" = "Animatie:";
-"Fade Window" = "Geest uit fles";
-"Slide Window" = "Glijdende schaal";
+"Fade Window" = "Venster fade-in"; /* This word exists, according to the Van Dale dictionary */
+"Slide Window" = "Venster inschuiven";
 
 "Screen:" = "Scherm:";
-"Show on all Spaces" = "Laat op alle Spaces zien";
+"Show on all Spaces" = "Laat zien op alle Spaces";
 "Show on top of the Dock" = "Blijf boven de Dock";
 "Free Form Window" = "Vrij venster";
 
 /* asepsis page */
-"Asepsis Feature" = "De asepsis optie";
+"Asepsis Feature" = "De asepsis-functie";
 "prevents .DS_Store files to be created in local folders" = "voorkomt aanmaken van .DS_Store bestanden in lokale mappen";
-".DS_Store files will be redirected into" = ".DS_Store bestanden worden omgezet naar";
-"this folder should be set as writable for all users of TotalFinder" = "deze map moet schrijfbaar zijn voor alle TotalFinder gebruikers";
-"Launch Migration Assistant" = "Start Migratie Assistent";
-"TotalFinder.kext status" = "TotalFinder.kext status";
-"Unable to connect" = "Kan niet verbinden met de kernel extensie!\nIs de TotalFinder kernel extensie geïnstalleerd?";
+".DS_Store files will be redirected into" = ".DS_Store bestanden worden omgeleid naar";
+"this folder should be set as writable for all users of TotalFinder" = "deze map moet beschrijfbaar zijn voor alle TotalFinder-gebruikers";
+"Launch Migration Assistant" = "Start Migratie-assistent";
+"TotalFinder.kext status" = "Status van TotalFinder.kext";
+"Unable to connect" = "Kan niet verbinden met de kernelextensie!\nIs de TotalFinder kernelextensie geïnstalleerd?";
 "Advanced:" = "Geavanceerd:";
 "Don't write .DS_Store to Network" = "Schrijf geen .DS_Store naar het netwerk";
 
 /* tweaks page */
-"Reset TotalFinder to defaults" = "Herstel de TotalFinder standaard instellingen";
+"Reset TotalFinder to defaults" = "Herstel de standaardinstellingen van TotalFinder";
 
 "File Browser:" = "Bestandverkenner:";
 "Show System Files" = "Toon systeembestanden";
-"Folders on Top" = "Mappen eerst";
+"Folders on Top" = "Mappen bovenaan";
 "Always Maximize" = "Altijd maximaliseren";
 "Toggle Dual Mode" = "Dubbele/enkele kolom";
 
 "Menu and Dock:" = "Menu en Dock:";
-"Hide icon in Menu Bar" = "Verwijder TotalFinder uit het status menu";
-"Keep original Dock icon" = "Behoud het originele Finder dock icon";
+"Hide icon in Menu Bar" = "Verberg icoon in menubalk";
+"Keep original Dock icon" = "Behoud het originele Dockicoon";
 
 "Experimental:" = "Experimenteel:";
-"Freelance Windows" = "Freelance schermen";
-"Use narrow Tabs Bar" = "Smalle tabbladbalk";
-"Show CutPaste buttons in Context Menus" = "Knip en plak knoppen in contextmenu's";
-"Allow path copying from Context Menus" = "Allow path copying from Context Menus";
+"Freelance Windows" = "Freelance-schermen";
+"Use narrow Tabs Bar" = "Gebruik smalle tabbalk";
+"Show CutPaste buttons in Context Menus" = "Toon knip- en plakknoppen in contextmenu's";
+"Allow path copying from Context Menus" = "Sta kopiëren van paden uit contextmenu's toe";
 
 /* about page */
-"Check Now" = "Check Now";
-"Check for Updates" = "Check for Updates";
-"Automatically check the website for updates" = "Automatically check the website for updates";
-"Include pre-releases" = "Include pre-releases";
-"Participate in TotalFinder testing" = "Participate in TotalFinder testing";
+"Check Now" = "Controleer nu";
+"Check for Updates" = "Controleer op updates";
+"Automatically check the website for updates" = "Controleer automatisch of er updates zijn";
+"Include pre-releases" = "Inclusief pre-releases";
+"Participate in TotalFinder testing" = "Deelnemen aan testen van TotalFinder";
 
 /* registration */
-"TotalFinder Registration" = "TotalFinder registratie";
+"TotalFinder Registration" = "Registratie van TotalFinder";
 "Registration" = "Registreren";
 "Please enter your license details from the email we have sent you:" = "Voer de licentiegegevens die u per e-mail van ons ontvangen hebt in:";
 "Buy TotalFinder Now" = "Koop TotalFinder nu";
 "Register" = "Registreer";
 "Thanks for registering!" = "Bedankt voor uw registratie!";
-"This TotalFinder copy is licensed to:" = "Deze TotalFinder is gelicenseerd aan:";
-"Close" = "Sluit";
+"This TotalFinder copy is licensed to:" = "Dit exemplaar van TotalFinder is gelicenseerd aan:";
+"Close" = "Sluiten";
 "Change License" = "Wijzig licentie";
 "Back" = "Terug";
 "Invalid license code" = "Ongeldige licentiecode";

--- a/plugin/Dutch.lproj/VisualImprovements.strings
+++ b/plugin/Dutch.lproj/VisualImprovements.strings
@@ -1,2 +1,2 @@
-"You are about to open more then four panes of file info. Maybe you forget to press Control or Option key?" = "U staat op het punt meer dan 4 panes met bestandsinfo te openen. Misschien bent u de Control of Option-toets vergeten indrukken?";
-"Are you sure you want to open?" = "Bent u zeker dat u wilt openen?";
+"You are about to open more then four panes of file info. Maybe you forget to press Control or Option key?" = "U staat op het punt meer dan vier panelen met bestandsinfo te openen. Misschien bent u de vergeten de Control of Option-toets vergeten in te drukken?";
+"Are you sure you want to open?" = "Weet u zeker dat u wilt doorgaan?";


### PR DESCRIPTION
Improved Dutch language files: translated untranslated strings, re-translated strings that were translated too literally and fixed a few spelling mistakes (mostly compositions ('samenstellingen') resulting in infamous 'spatiefouten')
