### PR TITLE
Russian translations for crash watcher and TotalFinderUI.strings

### DIFF
--- a/crashwatcher/Russian.lproj/Localizable.strings
+++ b/crashwatcher/Russian.lproj/Localizable.strings
@@ -1,0 +1,21 @@
+"crashDialogHeader" = "TotalFinder внезапно завершил работу";
+"crashDialogMsg" = "Мы извиняемся, но TotalFinder наткнулся на непредвиненную проблему и прервал работу Finder-у.";
+"crashDialogNote" = "Внимание: Finder перезапустился автоматически, но TotalFinder.app Вам необходимо запустить вручную.";
+"crashDialogExplanation" = "Кнопка 'отправить' загрузит отчёт об ошибке на gist.github.com и откроет Mail.app с темплейтом для письма.";
+
+"failDialogHeader" = "Невозможно загрузить отчёт об ошибке на gist.github.com";
+"failDialogMsg1" = "Очень жаль. Не удалось найти отчёт об ошибке в ~/Logs/CrashReporter.";
+"failDialogMsg2" = "Удалось найти итчёт об ошибке, но его загрузка на gist.github.com провалилась.\n\nЕсли это срочно, Вы можете послать отчёт вручную:\n%@";
+"failDialogOK" = "OK";
+
+"sendReportButton" = "Отправить Email";
+"cancelButton" = "Отмена";
+
+/* I think that emailTemplate should not be translated. It is a template for a bug report that is sent to the developer. He probably doesn't undertand Russian. */
+"emailTemplate" = "Hi Antonin,\n\nMy %@ just crashed!\n\nThe crash report is available here:\n%@\n\n>\n> You may help me fix the problem by describing what happened before the crash.\n> I appreciate your help and I read these crash reports, but don't expect my direct answer.\n> For further discussion please open a topic at\n> http://getsatisfaction.com/binaryage.\n>\n> Thank you, Antonin";
+
+"countdownMsgSecondsPlural" = "Осталось %d секунд.";
+"countdownMsgSecondSingular" = "Осталась %d секунда.";
+
+"countdownMsgMinutesPlural" = "Осталось %d минут.";
+"countdownMsgMinuteSingular" = "Осталась %d минута.";

--- a/plugin/Russian.lproj/TotalFinderUI.strings
+++ b/plugin/Russian.lproj/TotalFinderUI.strings
@@ -54,11 +54,11 @@
 "Allow path copying from Context Menus" = "Меню копирования пути файла";
 
 /* about page */
-"Check Now" = "Check Now";
-"Check for Updates" = "Check for Updates";
-"Automatically check the website for updates" = "Automatically check the website for updates";
-"Include pre-releases" = "Include pre-releases";
-"Participate in TotalFinder testing" = "Participate in TotalFinder testing";
+"Check Now" = "Проверить сейчас";
+"Check for Updates" = "Проверить обновления";
+"Automatically check the website for updates" = "Автоматически проверять обновления на веб-странице";
+"Include pre-releases" = "Включить в обновления pre-релизы";
+"Participate in TotalFinder testing" = "Принять участие в программе тестирования TotalFinder";
 
 /* registration */
 "TotalFinder Registration" = "Регистрация TotalFinder";


### PR DESCRIPTION
Added missing Russian translations for:

crashwatcher/Russian.lproj/Localizable.strings
plugin/Russian.lproj/TotalFinderUI.strings
