### PR TITLE
Corrected typo in Template.strings [ITA]

### DIFF
--- a/plugin/Italian.lproj/Template.strings
+++ b/plugin/Italian.lproj/Template.strings
@@ -1,4 +1,4 @@
 "Template" = "Modello";
 "SAMPLE" = "SAMPLE";
-"Experimental" = "SPerimentale";
+"Experimental" = "Sperimentale";
 "Enable Template" = "Abilita modello";


### PR DESCRIPTION
I just corrected a capitalization typo in Template.strings.
Cheers!

Diego
