### PR TITLE
Added chinese translation in TotalFinder.strings

### DIFF
--- a/plugin/zh_CN.lproj/TotalFinder.strings
+++ b/plugin/zh_CN.lproj/TotalFinder.strings
@@ -25,7 +25,7 @@
 "Visit Homepage…" = "访问主页…";
 
 /* registration */
-"Licensed to %@" = "已注册给：%@";
+"Licensed to %@" = "已注册给 %@";
 "Change License" = "更换注册码";
 "Unregistered version in trial mode" = "未注册试用版";
 "Register" = "注册";
@@ -81,6 +81,6 @@
 "Do you really want to disable tabs?" = "你真的要禁用标签吗？";
 "Do you really want to enable tabs?" = "你真的要启用标签吗？";
 "Tabs" = "标签";
-"This option will effectively disable the tabs module in TotalFinder. In effect the dual mode and visor functionality will be disabled as well. This may be desired under Mavericks - use native Finder tabs exclusively while keeping benefits of other TotalFinder features.\n\nFor this operation Finder has to be restarted!\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "该选项会禁用 TotalFinder 的标签模块，双窗口模式以及滑入窗口功能也将禁用。 如果你需要使用 Mavericks 里 Finder 的原生标签功能， 并同时使用 TotalFinder 的其他功能， 该选项可能有用。\n\n该操作需要重启 Finder ！\n注: 在重启前请先等待现有的 Finder 任务完成 （比如文件拷贝或移动）。";
-"This option will effectively enable the tabs module in TotalFinder.\n\nFor this operation Finder has to be restarted.\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "该选项会启用 TotalFinder 的标签模块。\n\n该操作需要重启 Finder ！\n注: 在重启前请先等待现有的 Finder 任务完成 （比如文件拷贝或移动）。";
-"This will effectively disable tabs, dual mode and visor. Finder restart is needed." = "这会禁用标签、 双窗口模式、 滑入窗口等功能。Finder 需要重启。";
+"This option will effectively disable the tabs module in TotalFinder. In effect the dual mode and visor functionality will be disabled as well. This may be desired under Mavericks - use native Finder tabs exclusively while keeping benefits of other TotalFinder features.\n\nFor this operation Finder has to be restarted!\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "该选项会禁用 TotalFinder 的标签模块，双窗口模式以及滑入窗口功能也将禁用。如果你需要使用 Mavericks 里 Finder 的原生标签功能，并同时使用 TotalFinder 的其他功能， 该选项可能有用。\n\n该操作需要重启 Finder！\n注: 在重启前请先等待现有的 Finder 任务完成 （比如文件拷贝或移动）。";
+"This option will effectively enable the tabs module in TotalFinder.\n\nFor this operation Finder has to be restarted.\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "该选项会启用 TotalFinder 的标签模块。\n\n该操作需要重启 Finder！\n注: 在重启前请先等待现有的 Finder 任务完成 （比如文件拷贝或移动）。";
+"This will effectively disable tabs, dual mode and visor. Finder restart is needed." = "这会禁用标签，双窗口模式， 滑入窗口等功能。Finder 需要重启。";

--- a/plugin/zh_CN.lproj/TotalFinder.strings
+++ b/plugin/zh_CN.lproj/TotalFinder.strings
@@ -67,9 +67,9 @@
 "Delete shortcut" = "删除快捷方式";
 "OK" = "好";
 "Record Shortcut" = "录制快捷方式";
-"Space" = "Space";
+"Space" = "空格键";
 "The key combination %@ cannot be used" = "无法使用此按键组合 %@";
-"This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences." = "This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences.";
+"This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences." = "无法使用此按键组合，因为已被系统快捷键所占用。\n若想使用此按键组合，则需要更改在 System Preferences 内 Keyboard & Mouse 的快捷键设置。";
 "This shortcut cannot be used because it is already used by the menu item ‘%@’." = "无法使用此按键组合，因为其已经被菜单项目‘%@’使用。";
 "Type New Shortcut" = "键入新快捷方式";
 "Type Shortcut" = "键入快捷方式";


### PR DESCRIPTION
Added Chinese translation in TotalFinder.strings. Translated "Space" and "This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences.". Names like "System Preferences" and "Keyboard & Mouse" are in English to match previous conventions.