### PR TITLE
Italian translation review

### DIFF
--- a/plugin/Italian.lproj/Labels.strings
+++ b/plugin/Italian.lproj/Labels.strings
@@ -1,2 +1,2 @@
-"Colored Labels" = "Colored Labels";
-"The last applied tag determines item's background color." = "The last applied tag determines item's background color.";
+"Colored Labels" = "Etichette Colorate";
+"The last applied tag determines item's background color." = "L'ultimo tag applicato determina il colore di sfondo dell'elemento.";

--- a/plugin/Italian.lproj/TotalFinder.strings
+++ b/plugin/Italian.lproj/TotalFinder.strings
@@ -69,18 +69,18 @@
 "Record Shortcut" = "Registra scorciatoia";
 "Space" = "Spazio";
 "The key combination %@ cannot be used" = "La combinazione di tasti %@ non può essere usata";
-"This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences." = "This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences.";
+"This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences." = "Questa combinazione non può essere usata perché già in uso come scorciatoia dal sistema operativo.\nSe vuoi realmente usare questa combinazione di tasti, puoi cambiare molte delle Abbreviazioni dal pannello Tastiera nelle Preferenze di Sistema.";
 "This shortcut cannot be used because it is already used by the menu item ‘%@’." = "Questa combinazione non può essere usata poiché è già usata dall'elemento di menu  ‘%@’.";
 "Type New Shortcut" = "Inserisci nuova scorciatoia";
 "Type Shortcut" = "Inserisci scorciatoia";
 "Use Old Shortcut" = "Usa vecchia scorciatoia";
-"Set it anyway" = "Set it anyway";
+"Set it anyway" = "Imposta comunque";
 
 /* tabs section */
-"Disable tabs completely" = "Disable tabs completely";
-"Do you really want to disable tabs?" = "Do you really want to disable tabs?";
-"Do you really want to enable tabs?" = "Do you really want to enable tabs?";
+"Disable tabs completely" = "Disabilita le schede completamente";
+"Do you really want to disable tabs?" = "Vuoi veramente disabilitare le schede?";
+"Do you really want to enable tabs?" = "Vuoi veramente abilitare le schede?";
 "Tabs" = "Schede";
-"This option will effectively disable the tabs module in TotalFinder. In effect the dual mode and visor functionality will be disabled as well. This may be desired under Mavericks - use native Finder tabs exclusively while keeping benefits of other TotalFinder features.\n\nFor this operation Finder has to be restarted!\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "This option will effectively disable the tabs module in TotalFinder. In effect the dual mode and visor functionality will be disabled as well. This may be desired under Mavericks - use native Finder tabs exclusively while keeping benefits of other TotalFinder features.\n\nFor this operation Finder has to be restarted!\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files).";
-"This option will effectively enable the tabs module in TotalFinder.\n\nFor this operation Finder has to be restarted.\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "This option will effectively enable the tabs module in TotalFinder.\n\nFor this operation Finder has to be restarted.\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files).";
-"This will effectively disable tabs, dual mode and visor. Finder restart is needed." = "This will effectively disable tabs, dual mode and visor. Finder restart is needed.";
+"This option will effectively disable the tabs module in TotalFinder. In effect the dual mode and visor functionality will be disabled as well. This may be desired under Mavericks - use native Finder tabs exclusively while keeping benefits of other TotalFinder features.\n\nFor this operation Finder has to be restarted!\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "Questa opzione disabiliterà effettivamente il modulo schede di TotalFinder. Anche le funzionalità doppio pannello ed il visore saranno disabilitati. Questo può essere voluto in Mavericks - usa esclusivamente le schede del Finder nativo mantenendo i benefici delle altre caratteristiche di TotalFinder .\n\nPer questa operazione il Finder deve essere riavviato!\nNota: Prima di riavviare, finisci tutte le operazioni del Finder in corso (ad esempio copiare o spostare file).";
+"This option will effectively enable the tabs module in TotalFinder.\n\nFor this operation Finder has to be restarted.\nNote: Prior restarting please finish all Finder tasks in progress (like copying or moving files)." = "Questa opzione abiliterà effettivamente il modulo schede di TotalFinder.\n\nPer questa operazione il Finder deve essere riavviato.\nNota: Prima di riavviare, finisci tutte le operazioni del Finder in corso (ad esempio copiare o spostare file).";
+"This will effectively disable tabs, dual mode and visor. Finder restart is needed." = "Questo disabiliterà effettivamente le schede, la modalità doppia ed il visore. Il Finder deve essere riavviato.";

--- a/plugin/Italian.lproj/Visor.strings
+++ b/plugin/Italian.lproj/Visor.strings
@@ -16,4 +16,4 @@
 "Hide on ESC" = "Premi ESC per nascondere";
 "Screen:" = "Schermo:";
 "Screen" = "Schermo";
-"Screen with Mouse Cursor" = "Screen with Mouse Cursor";
+"Screen with Mouse Cursor" = "Schermo con cursore mouse";

--- a/uninstaller/Italian.lproj/Localizable.strings
+++ b/uninstaller/Italian.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+/* buttons */
+"Quit" = "Chiudi";
+"Cancel" = "Cancella";
+"Uninstall" = "Disinstalla";
+"Details" = "Dettagli";
+
+/* tooltips */
+"Show detailed transcript" = "Visualizza trascrizione dettagliata";
+
+/* main texts */
+"You are about uninstall *APP*" = "Stai per disinstallare TotalFinder";
+"This program will uninstall all *APP* components from this computer." = "Questo programma eliminerà tutti i componenti di TotalFinder da questo computer.";
+"*APP* has been uninstalled" = "TotalFinder è stato disinstallato";
+"Have a nice day." = "Buona giornata.";
+"*APP* uninstallation failed" = "Disinstallazione di TotalFinder fallita";
+"The uninstall script encountered problems. Please see the details. Please report bugs to support@binaryage.com." = "Lo script di rimozione ha incontrato dei problemi. Per favore guarda i dettagli. Per favore segnala i problemi a support@binaryage.com.";
+
+/* possible script messages in details section */
+"Uninstaller needs admin privileges to remove *APP* from your system." = "Lo script di rimozione ha bisogno dei privilegi di amministratore per rimuovere TotalFinder dal tuo sistema.";
+"Running uninstall script:\n" = "Eseguo lo script di rimozione:\n";
+"Uninstall script finished successfully.\n" = "Script di rimozione eseguito con successo.\n";
+"Uninstall script needs admin rights.\n" = "Lo script di rimozione ha bisogno dei privilegi di amministratore.\n";
+"Uninstall script failed with error [%d].\n" = "Lo script di rimozione è terminato con errore [%d].\n";


### PR DESCRIPTION
Hello from Italy, this app is really good but i found some lack in the Italian translation and I am here to contribute.

As you can see I have completed the translation in some strings files and added a brand new file for the uninstall script.

I have a question for the file "plugin/Italian.lproj/TotalFinder.strings", line 72 says "Keyboard & Mouse", on my mac shortcuts options are in the "Tastiera (Keyboard)" tab so it's ok if in my translation i say only "Keyboard" instead of "Keyboard & Mouse"?
